### PR TITLE
Fix map deletion check

### DIFF
--- a/king.go
+++ b/king.go
@@ -108,10 +108,10 @@ func deleteMap(channel chan<- bool) { // Function that deletes the map file on /
 	err := os.Remove(mapPath)
 	if err != nil {
 		fmt.Println(err)
-		channel <- delCheck
+		channel <- isMapDeleted
 	}
 
-	delCheck = true
-	channel <- delCheck
+	isMapDeleted = true
+	channel <- isMapDeleted
 
 }

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import(
 
 //Constants
 const kingPath = "king.txt" // Path to king file
-const mapPath = "map.txt" // Path to map file
-const flags = 4 // amount of flags
-var delCheck = false // Initial assignment of the /api/delete check bool
+const mapPath = "map.txt"   // Path to map file
+const flags = 4             // amount of flags
+var isMapDeleted = false    // Initial assignment of the /api/delete check bool
 
 func main() {
 

--- a/serv.go
+++ b/serv.go
@@ -1,8 +1,7 @@
 package main
 
-import(
+import (
 	"net/http"
-	"fmt"
 )
 
 func serv() {
@@ -33,7 +32,7 @@ func returnFlags(w http.ResponseWriter, r *http.Request) {
 	case "GET":	// GET - returns flag.txt
 		w.Write(readKing())
 	case "POST": // POST - If /api/delete hasn't been run yet, supply flags as JSON, if /api/delete has been run, "Status Not Implemented" response.
-		if delCheck != false {
+		if isMapDeleted == true {
 
 			w.WriteHeader(http.StatusNotImplemented)
 			w.Write([]byte(http.StatusText(http.StatusNotImplemented) + "\n"))
@@ -62,13 +61,11 @@ func handleDelete(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		w.Write(readKing())
 	case "POST":
-		if delCheck != false {
+		if isMapDeleted == true {
 			w.WriteHeader(http.StatusNotImplemented)
 			w.Write([]byte(http.StatusText(http.StatusNotImplemented) + "\n"))
 			break
-		}
-
-		if delCheck == true {
+		} else {
 
 			statusChan := make(chan bool) // Opens response channel
 


### PR DESCRIPTION
So basically the /api/delete route handler performed the same deletion check twice so the actual map file deletion code couldn't be reached